### PR TITLE
BP-14464: Update subscription URL for OIM integrations

### DIFF
--- a/sns.tf
+++ b/sns.tf
@@ -5,5 +5,5 @@ resource "aws_sns_topic" "sns_topic" {
 resource "aws_sns_topic_subscription" "sns_subscription" {
   topic_arn = aws_sns_topic.sns_topic.arn
   protocol  = "https"
-  endpoint  = "${var.api_endpoint}/cloudwatch/alerts?access_token=${var.bearer_token}&app_key=${var.app_key}"
+  endpoint  = "${var.api_endpoint}/cloudwatch_v2/alerts?access_token=${var.bearer_token}&app_key=${var.app_key}"
 }


### PR DESCRIPTION
Prior to OIM, our alerts endpoint was `https://integrations.bigpanda.io/cloudwatch/alarms`, so this was valid.

OIM, however, uses the BigPanda system name for determining source system, default config, etc. so it needs to use `cloudwatch_v2` instead of `cloudwatch`.

We never plan to move back to pre-OIM, so this should be fine.