### PR TITLE
BP-14508: Update CloudWatch subscription Lambda to use Node20.x runtime

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_function" "bigpanda_lambda" {
   # "handler" is the name of the property under which the handler function was
   # exported in the attached zip file.
   handler     = "CloudwatchBigpandaAddTopic.handler"
-  runtime     = "nodejs16.x"
+  runtime     = "nodejs20.x"
   timeout     = 900
   memory_size = 256
   role        = local.bigpanda_role_arn


### PR DESCRIPTION
The `.zip` file that has been updated is what the Lambda will ultimately run. For a detailed description of what was changed, see [the file on the PR in the int-cloudwatch project.](https://github.com/bigpandaio/int-cloudwatch/pull/40/files#diff-c9b63b71fc2bb622cb756c1af62f847e01c6478f9149dbba89f99d61463d0f42)